### PR TITLE
Feat(ui): update bottom navigation bar

### DIFF
--- a/app/ui/lib/presentation/widgets/app_bottom_navigation_bar.dart
+++ b/app/ui/lib/presentation/widgets/app_bottom_navigation_bar.dart
@@ -15,16 +15,16 @@ class AppBottomNavigationBar extends StatelessWidget {
             label: 'Home',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.category),
-            label: 'Categories',
+            icon: Icon(Icons.person),
+            label: 'Profile',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.shopping_cart),
             label: 'Cart',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.person),
-            label: 'Profile',
+            icon: Icon(Icons.menu),
+            label: "Menu"
           ),
         ],
         currentIndex: currentIndex,

--- a/app/ui/test/presentation/widgets/app_bottom_navigation_bar_test.dart
+++ b/app/ui/test/presentation/widgets/app_bottom_navigation_bar_test.dart
@@ -54,7 +54,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Assert
-      expect(tappedIndex, 1);
+      expect(tappedIndex, 3);
     });
 
     testWidgets('should set currentIndex correctly', (WidgetTester tester) async {

--- a/app/ui/test/presentation/widgets/app_bottom_navigation_bar_test.dart
+++ b/app/ui/test/presentation/widgets/app_bottom_navigation_bar_test.dart
@@ -24,7 +24,7 @@ void main() {
       // Assert
       expect(find.byType(BottomNavigationBar), findsOneWidget);
       expect(find.byIcon(Icons.home), findsOneWidget);
-      expect(find.byIcon(Icons.category), findsOneWidget);
+      expect(find.byIcon(Icons.menu), findsOneWidget);
       expect(find.byIcon(Icons.shopping_cart), findsOneWidget);
       expect(find.byIcon(Icons.person), findsOneWidget);
     });
@@ -50,7 +50,7 @@ void main() {
       );
 
       // Tap on the Categories icon
-      await tester.tap(find.byIcon(Icons.category));
+      await tester.tap(find.byIcon(Icons.menu));
       await tester.pumpAndSettle();
 
       // Assert


### PR DESCRIPTION
This pull request includes changes to the `app_bottom_navigation_bar.dart` and its corresponding test file to update the icons and labels in the bottom navigation bar. The most important changes include replacing the 'Categories' icon with a 'Profile' icon and the 'Profile' icon with a 'Menu' icon.

Updates to bottom navigation bar:

* [`app/ui/lib/presentation/widgets/app_bottom_navigation_bar.dart`](diffhunk://#diff-d678d79cc1dcbd172c634dfdb4c8c0464f7aead3007618410ec91a5d3f3df393L18-R27): Replaced the 'Categories' icon and label with 'Profile', and the 'Profile' icon and label with 'Menu'.

Updates to tests:

* [`app/ui/test/presentation/widgets/app_bottom_navigation_bar_test.dart`](diffhunk://#diff-bfa7701439072f01d07d19303b9b28c1cc42c4143c5ce69d342865fb4ac58e92L27-R27): Updated the test cases to reflect the changes in the bottom navigation bar by replacing 'Categories' with 'Menu'. [[1]](diffhunk://#diff-bfa7701439072f01d07d19303b9b28c1cc42c4143c5ce69d342865fb4ac58e92L27-R27) [[2]](diffhunk://#diff-bfa7701439072f01d07d19303b9b28c1cc42c4143c5ce69d342865fb4ac58e92L53-R53)