### PR TITLE
Feat: update products by category route

### DIFF
--- a/app/api/src/main/java/com/somba/api/adapter/controllers/ProductController.java
+++ b/app/api/src/main/java/com/somba/api/adapter/controllers/ProductController.java
@@ -6,7 +6,7 @@ import com.somba.api.adapter.mappers.ProductMapper;
 import com.somba.api.adapter.presenters.ProductView;
 import com.somba.api.adapter.presenters.Response;
 import com.somba.api.core.usecases.ListProductsUseCase;
-import com.somba.api.core.usecases.SearchProductsByCategoryUsecase;
+import com.somba.api.core.usecases.ListProductsByCategoryUsecase;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,11 +25,11 @@ import jakarta.websocket.server.PathParam;
 public class ProductController {
 
   private final ListProductsUseCase listProductsUseCase;
-  private final SearchProductsByCategoryUsecase searchProductsByCategoryUsecase;
+  private final ListProductsByCategoryUsecase searchProductsByCategoryUsecase;
   private final ProductMapper productMapper;
 
   public ProductController(ListProductsUseCase listProductsUseCase,
-      SearchProductsByCategoryUsecase searchProductsByCategoryUsecase, ProductMapper productMapper) {
+      ListProductsByCategoryUsecase searchProductsByCategoryUsecase, ProductMapper productMapper) {
     this.listProductsUseCase = listProductsUseCase;
     this.searchProductsByCategoryUsecase = searchProductsByCategoryUsecase;
     this.productMapper = productMapper;

--- a/app/api/src/main/java/com/somba/api/adapter/controllers/ProductController.java
+++ b/app/api/src/main/java/com/somba/api/adapter/controllers/ProductController.java
@@ -9,12 +9,15 @@ import com.somba.api.core.usecases.ListProductsUseCase;
 import com.somba.api.core.usecases.SearchProductsByCategoryUsecase;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.Min;
+import jakarta.websocket.server.PathParam;
 
 @RestController
 @RequestMapping("/api/v1/products")
@@ -47,18 +50,20 @@ public class ProductController {
   }
 
   @GetMapping(
-    path = "/search",
-    produces = { "application/json" }, params = { "category" })
+    path = "/categories/{category}",
+    produces = { "application/json" }
+  )
   public Response<List<ProductView>> listProductsByCategory(
-      @RequestParam String category,
+      @PathVariable String category,
       @RequestParam(defaultValue = "0") @Min(value = 0, message = "Page number must be greater than or equal to 0") int page,
-      @RequestParam(defaultValue = "10") @Min(value = 1, message = "Page size must be greater than or equal to 1") int size
+      @RequestParam(defaultValue = "10") @Min(value = 1, message = "Page size must be greater than or equal to 1") int size,
+      WebRequest request
   ){
     return new Response<>(
       200,
       "Successfully retrieved the list of products of category: " + category,
       searchProductsByCategoryUsecase.execute(category, page, size).parallelStream().map(productMapper::toProductView).toList(),
-      "/api/v1/products/search?category=" + category + "&page=" + page + "&size=" + size,
+      request.getDescription(false).replace("uri=", "") + "?page=" + page + "&size=" + size,
       java.time.LocalDateTime.now()
     );
   }

--- a/app/api/src/main/java/com/somba/api/core/usecases/ListProductsByCategoryUsecase.java
+++ b/app/api/src/main/java/com/somba/api/core/usecases/ListProductsByCategoryUsecase.java
@@ -10,11 +10,11 @@ import com.somba.api.core.exceptions.InvalidPaginationParameterException;
 import com.somba.api.core.ports.ProductRepository;
 
 @Service
-public class SearchProductsByCategoryUsecase {
+public class ListProductsByCategoryUsecase {
 
   private final ProductRepository productRepository;
 
-  public SearchProductsByCategoryUsecase(ProductRepository productRepository) {
+  public ListProductsByCategoryUsecase(ProductRepository productRepository) {
     this.productRepository = productRepository;
   }
   

--- a/app/api/src/test/java/com/somba/api/core/usecases/ListProductsByCategoryUsecaseTest.java
+++ b/app/api/src/test/java/com/somba/api/core/usecases/ListProductsByCategoryUsecaseTest.java
@@ -23,7 +23,7 @@ import com.somba.api.core.exceptions.NullCategoryException;
 import com.somba.api.core.ports.ProductRepository;
 
 @ExtendWith(MockitoExtension.class)
-class SearchProductsByCategoryUsecaseTest {
+class ListProductsByCategoryUsecaseTest {
 
   @Mock
   private ProductRepository productRepository;

--- a/app/api/src/test/java/com/somba/api/core/usecases/SearchProductsByCategoryUsecaseTest.java
+++ b/app/api/src/test/java/com/somba/api/core/usecases/SearchProductsByCategoryUsecaseTest.java
@@ -29,7 +29,7 @@ class SearchProductsByCategoryUsecaseTest {
   private ProductRepository productRepository;
 
   @InjectMocks
-  private SearchProductsByCategoryUsecase searchProductsByCategoryUsecase;
+  private ListProductsByCategoryUsecase searchProductsByCategoryUsecase;
 
   private List<Product> generateProducts(int size, Category category) {
     return IntStream.range(0, size)

--- a/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
@@ -65,7 +65,7 @@ class PaginatedProductsByCategoryE2ETest {
 
   @BeforeEach
   public void setUp() {
-    baseUrl = "http://localhost:" + port + "/api/v1/products";
+    baseUrl = "http://localhost:" + port + "/api/v1/products/categories";
 
     // Clear existing data
     productRepository.deleteAll();
@@ -85,7 +85,7 @@ class PaginatedProductsByCategoryE2ETest {
   void testSearchByCategory() {
     // Given
     String category = "electronics";
-    String url = baseUrl + "/search?category=" + category;
+    String url = baseUrl + "/" + category;
 
     // When
     var response = restTemplate.getForEntity(url, String.class);
@@ -103,7 +103,7 @@ class PaginatedProductsByCategoryE2ETest {
           () -> assertThat(products.message()).isEqualTo("Successfully retrieved the list of products of category: " + category),
           () -> assertThat(products.data()).hasSize(10),
           () -> assertThat(products.path())
-              .isEqualTo("/api/v1/products/search?category=" + category + "&page=0&size=10"),
+              .isEqualTo("/api/v1/products/categories/electronics?page=0&size=10"),
           () -> assertThat(products.timestamp()).isNotNull());
     } catch (Exception e) {
       e.printStackTrace();
@@ -115,7 +115,7 @@ class PaginatedProductsByCategoryE2ETest {
   void testSearchByCategoryWithPagination() {
     // Given
     String category = "electronics";
-    String url = baseUrl + "/search?category=" + category + "&page=0&size=5";
+    String url = baseUrl + "/" + category;
 
     // When
     var response = restTemplate.getForEntity(url, String.class);
@@ -133,7 +133,7 @@ class PaginatedProductsByCategoryE2ETest {
           () -> assertThat(products.message()).isEqualTo("Successfully retrieved the list of products of category: " + category),
           () -> assertThat(products.data()).hasSize(5),
           () -> assertThat(products.path())
-              .isEqualTo("/api/v1/products/search?category=" + category + "&page=0&size=5"),
+              .isEqualTo("/api/v1/products/categories/" + category + "?page=0&size=10"),
           () -> assertThat(products.timestamp()).isNotNull());
     } catch (Exception e) {
       e.printStackTrace();
@@ -145,7 +145,7 @@ class PaginatedProductsByCategoryE2ETest {
   void testSearchByCategoryWithInvalidCategory() {
     // Given
     String category = "invalid";
-    String url = baseUrl + "/search?category=" + category;
+    String url = baseUrl + "/" + category;
 
     // When
     var response = restTemplate.getForEntity(url, String.class);
@@ -163,7 +163,7 @@ class PaginatedProductsByCategoryE2ETest {
                       .map(Enum::name)
                       .collect(Collectors.joining(", "))
           ),
-          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/search"),
+          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/categories/invalid"),
           () -> assertThat(errorDetails.timestamp()).isNotNull());
 
     } catch (Exception e) {
@@ -176,7 +176,7 @@ class PaginatedProductsByCategoryE2ETest {
   void testSearchByCategoryWithInvalidPageParameter() {
     // Given
     String category = "electronics";
-    String url = baseUrl + "/search?category=" + category + "&page=-1&size=10";
+    String url = baseUrl + "/" + category + "?page=-1";
 
     // When
     var response = restTemplate.getForEntity(url, String.class);
@@ -192,7 +192,7 @@ class PaginatedProductsByCategoryE2ETest {
           () -> assertThat(errorDetails.message()).isEqualTo("Validation failed for one or more fields."),
           () -> assertThat(errorDetails.details()).isNotNull().isNotEmpty(),
           () -> assertThat(errorDetails.details()).contains("page: Page number must be greater than or equal to 0"),
-          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/search"),
+          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/categories/electronics"),
           () -> assertThat(errorDetails.timestamp()).isNotNull());
 
     } catch (Exception e) {
@@ -205,7 +205,7 @@ class PaginatedProductsByCategoryE2ETest {
   void testSearchByCategoryWithInvalidSizeParameter() {
     // Given
     String category = "electronics";
-    String url = baseUrl + "/search?category=" + category + "&page=1&size=0";
+    String url = baseUrl + "/" + category + "?page=1&size=0";
 
     // When
     var response = restTemplate.getForEntity(url, String.class);
@@ -221,7 +221,7 @@ class PaginatedProductsByCategoryE2ETest {
           () -> assertThat(errorDetails.message()).isEqualTo("Validation failed for one or more fields."),
           () -> assertThat(errorDetails.details()).isNotNull().isNotEmpty(),
           () -> assertThat(errorDetails.details()).contains("size: Page size must be greater than or equal to 1"),
-          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/search"),
+          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/categories/electronics"),
           () -> assertThat(errorDetails.timestamp()).isNotNull());
 
     } catch (Exception e) {
@@ -234,7 +234,7 @@ class PaginatedProductsByCategoryE2ETest {
   void testSearchByCategoryWithInvalidPageAndSizeParameters() {
     // Given
     String category = "electronics";
-    String url = baseUrl + "/search?category=" + category + "&page=-1&size=0";
+    String url = baseUrl + "/" + category + "?page=-1&size=0";
 
     // When
     var response = restTemplate.getForEntity(url, String.class);
@@ -253,7 +253,7 @@ class PaginatedProductsByCategoryE2ETest {
               "page: Page number must be greater than or equal to 0",
               "size: Page size must be greater than or equal to 1"
           ),
-          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/search"),
+          () -> assertThat(errorDetails.path()).isEqualTo("/api/v1/products/categories/electronics"),
           () -> assertThat(errorDetails.timestamp()).isNotNull());
 
     } catch (Exception e) {

--- a/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
@@ -34,7 +34,7 @@ import com.somba.api.core.ports.ProductRepository;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
     "spring.profiles.active=test" })
 @Testcontainers
-class SearchByCategoryE2ETest {
+class PaginatedProductsByCategoryE2ETest {
 
   @Container
   static final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest");

--- a/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
@@ -115,7 +115,7 @@ class PaginatedProductsByCategoryE2ETest {
   void testSearchByCategoryWithPagination() {
     // Given
     String category = "electronics";
-    String url = baseUrl + "/" + category;
+    String url = baseUrl + "/" + category + "?page=0&size=5";
 
     // When
     var response = restTemplate.getForEntity(url, String.class);
@@ -133,7 +133,7 @@ class PaginatedProductsByCategoryE2ETest {
           () -> assertThat(products.message()).isEqualTo("Successfully retrieved the list of products of category: " + category),
           () -> assertThat(products.data()).hasSize(5),
           () -> assertThat(products.path())
-              .isEqualTo("/api/v1/products/categories/" + category + "?page=0&size=10"),
+              .isEqualTo("/api/v1/products/categories/" + category + "?page=0&size=5"),
           () -> assertThat(products.timestamp()).isNotNull());
     } catch (Exception e) {
       e.printStackTrace();

--- a/app/ui/lib/data/datasources/remote/product_remote_data_source.dart
+++ b/app/ui/lib/data/datasources/remote/product_remote_data_source.dart
@@ -26,7 +26,7 @@ class ProductRemoteDataSource {
   Future<List<ProductItemModel>> getProductsByCategory(
       {required String category, required int page, required int perPage}) async {
     final response = await client.get(
-        Uri.parse('http://localhost:8081/api/v1/products/search?category=$category&page=$page&size=$perPage'));
+        Uri.parse('http://localhost:8081/api/v1/products/categories/$category?page=$page&size=$perPage'));
     if (response.statusCode == 200) {
       final Map<String, dynamic> jsonResponse = json.decode(response.body);
       final List<dynamic> products = jsonResponse['data'];

--- a/app/ui/test/datasources/remote/product_remote_data_source_test.dart
+++ b/app/ui/test/datasources/remote/product_remote_data_source_test.dart
@@ -105,7 +105,7 @@ void main() {
     const String category = 'Electronics';
     const int page = 1;
     const int perPage = 10;
-    final String endpoint = '$baseUrl/search?category=$category&page=$page&size=$perPage';
+    final String endpoint = '$baseUrl/categories/$category?page=$page&size=$perPage';
 
     final tProductListByCategory = [
       ProductItemModel(id: '3', name: 'Electronics Product 1', brand: 'Brand E1', price: 3000),


### PR DESCRIPTION
This pull request includes several changes to rename the `SearchProductsByCategoryUsecase` to `ListProductsByCategoryUsecase` and update related endpoints and tests accordingly. The main changes involve updating the controller, use case class, and test files to reflect the new naming convention and endpoint structure.

### Controller Updates:
* [`ProductController.java`](diffhunk://#diff-761179cde6848dbca3bcb78142758220097c4b0ec639fc1e0068f3a87a509022L9-R32): Renamed `SearchProductsByCategoryUsecase` to `ListProductsByCategoryUsecase` and updated the endpoint from `/search` to `/categories/{category}`. [[1]](diffhunk://#diff-761179cde6848dbca3bcb78142758220097c4b0ec639fc1e0068f3a87a509022L9-R32) [[2]](diffhunk://#diff-761179cde6848dbca3bcb78142758220097c4b0ec639fc1e0068f3a87a509022L50-R66)

### Use Case Renaming:
* [`ListProductsByCategoryUsecase.java`](diffhunk://#diff-7fe07f47cbdfc03fa8228512c6545b5466f7906c0e24718dc357b5718f24eae6L13-R17): Renamed from `SearchProductsByCategoryUsecase.java` and updated class name and constructor accordingly.

### Test File Updates:
* [`ListProductsByCategoryUsecaseTest.java`](diffhunk://#diff-fb6c5b7c2fb343793884544f5034925739b3e0b282a41605e23be043cb7d0854L26-R32): Renamed from `SearchProductsByCategoryUsecaseTest.java` and updated class name and constructor accordingly.
* [`PaginatedProductsByCategoryE2ETest.java`](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L37-R37): Renamed from `SearchByCategoryE2ETest.java` and updated base URL and test methods to reflect the new endpoint structure. [[1]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L37-R37) [[2]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L68-R68) [[3]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L88-R88) [[4]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L106-R106) [[5]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L118-R118) [[6]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L136-R136) [[7]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L148-R148) [[8]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L166-R166) [[9]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L179-R179) [[10]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L195-R195) [[11]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L208-R208) [[12]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L224-R224) [[13]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L237-R237) [[14]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L256-R256)

### UI Data Source Update:
* [`product_remote_data_source.dart`](diffhunk://#diff-b56bbe7d6b1e2c2f5979a80cac5be207207a5667c59bbe0eea77f013a563c05fL29-R29): Updated the endpoint URL in `getProductsByCategory` method to reflect the new `/categories/{category}` structure.

### UI Test Update:
* [`product_remote_data_source_test.dart`](diffhunk://#diff-9d4ff328f61725b27fe70fd0cfec977ef8fd7da54f4471c2b18d6ced23227c95L108-R108): Updated the endpoint URL in test cases to reflect the new `/categories/{category}` structure.