### PR TITLE
Feat(ci): configure e2e test with docker

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -6,8 +6,8 @@ on:
       - main
       - develop
   pull_request:
-    types: [ opened, synchronize, reopened ]
-    branches: [ '**' ]
+    types: [opened, synchronize, reopened]
+    branches: ["**"]
 
 concurrency:
   group: api-${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -19,7 +19,7 @@ jobs:
     with:
       base_ref: ${{ github.event.pull_request.base.sha || github.event.before }}
       head_ref: ${{ github.event.pull_request.head.sha || github.event.after }}
-      paths: 'app/api .github/workflows/api-ci.yml .github/workflows/path-change-detector.yml'
+      paths: "app/api .github/workflows/api-ci.yml .github/workflows/path-change-detector.yml"
 
   Build_and_Test:
     name: Build and Test
@@ -28,26 +28,12 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      JAVA_VERSION: '21'
-      MAVEN_OPTS: '-Xmx2g'
+      JAVA_VERSION: "21"
+      MAVEN_OPTS: "-Xmx2g"
       SONAR_TOKEN: ${{ secrets.API_SONAR_TOKEN }}
       SONAR_ORGANIZATION: jarhead-killgrave
       SONAR_HOST_URL: https://sonarcloud.io
       SONAR_PROJECT_KEY: com.somba:api
-
-      # Provide defaults or secrets for your DB, Mongo, etc.
-      DB_USER: postgres
-      DB_PASSWORD: postgres
-      DB_NAME: test_db
-      DB_PORT: 5432
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: root
-      MONGO_DB: test_mongo
-      MONGO_PORT: 27017
-      ELASTICSEARCH_JAVA_OPTS: '-Xms256m -Xmx256m'
-      ELASTICSEARCH_PORT: 9200
-      ELASTICSEARCH_PORT_ALT: 9300
-      KIBANA_PORT: 5601
 
     steps:
       - name: Checkout Repository
@@ -56,9 +42,9 @@ jobs:
       - name: Set Up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: ${{ env.JAVA_VERSION }}
-          cache: 'maven'
+          cache: "maven"
 
       - name: Cache Maven Dependencies
         uses: actions/cache@v4
@@ -75,7 +61,10 @@ jobs:
         run: mvn --version
         working-directory: ./app/api
 
-      # Start only required services
+      - name: Copy Environment Variables
+        run: cp .env.ci .env
+        working-directory: ./app/api
+
       - name: Start Docker Services (CI)
         run: docker compose -f docker-compose.ci.yml up -d --build
         working-directory: ./app/api

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       # Start only required services
       - name: Start Docker Services (CI)
-        run: docker-compose -f docker-compose.ci.yml up -d --build
+        run: docker compose -f docker-compose.ci.yml up -d --build
 
       - name: Wait for services to be healthy
         run: |

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -19,17 +19,14 @@ jobs:
     with:
       base_ref: ${{ github.event.pull_request.base.sha || github.event.before }}
       head_ref: ${{ github.event.pull_request.head.sha || github.event.after }}
-      paths: 'app/api'
+      paths: 'app/api .github/workflows/api-ci.yml .github/workflows/path-change-detector.yml'
 
   Build_and_Test:
     name: Build and Test
-
     needs: path-check
-
     if: needs.path-check.outputs.changes_detected == 'true'
-
     runs-on: ubuntu-latest
-    
+
     env:
       JAVA_VERSION: '21'
       MAVEN_OPTS: '-Xmx2g'
@@ -37,6 +34,20 @@ jobs:
       SONAR_ORGANIZATION: jarhead-killgrave
       SONAR_HOST_URL: https://sonarcloud.io
       SONAR_PROJECT_KEY: com.somba:api
+
+      # Provide defaults or secrets for your DB, Mongo, etc.
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: test_db
+      DB_PORT: 5432
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+      MONGO_DB: test_mongo
+      MONGO_PORT: 27017
+      ELASTICSEARCH_JAVA_OPTS: '-Xms256m -Xmx256m'
+      ELASTICSEARCH_PORT: 9200
+      ELASTICSEARCH_PORT_ALT: 9300
+      KIBANA_PORT: 5601
 
     steps:
       - name: Checkout Repository
@@ -64,6 +75,16 @@ jobs:
         run: mvn --version
         working-directory: ./app/api
 
+      # Start only required services
+      - name: Start Docker Services (CI)
+        run: docker-compose -f docker-compose.ci.yml up -d --build
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Sleeping for 20s to allow services to start..."
+          sleep 20
+          docker ps
+
       - name: Build and Test with Maven
         run: mvn clean verify --fail-fast -Dspring.profiles.active=test
         working-directory: ./app/api
@@ -74,7 +95,6 @@ jobs:
           args: >
             -Dsonar.token=${{ env.SONAR_TOKEN }}
           projectBaseDir: ./app/api
-
 
       - name: Upload Test Reports
         if: always()
@@ -89,3 +109,7 @@ jobs:
         with:
           name: jacoco-report
           path: ./app/api/target/site/jacoco/
+
+      - name: Tear Down Docker Services (CI)
+        if: always()
+        run: docker-compose -f docker-compose.ci.yml down

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -78,6 +78,7 @@ jobs:
       # Start only required services
       - name: Start Docker Services (CI)
         run: docker compose -f docker-compose.ci.yml up -d --build
+        working-directory: ./app/api
 
       - name: Wait for services to be healthy
         run: |
@@ -112,4 +113,5 @@ jobs:
 
       - name: Tear Down Docker Services (CI)
         if: always()
-        run: docker-compose -f docker-compose.ci.yml down
+        run: docker compose -f docker-compose.ci.yml down
+        working-directory: ./app/api

--- a/app/api/.env.ci
+++ b/app/api/.env.ci
@@ -1,0 +1,50 @@
+# ----------------------------------------
+# Application (Test/CI) Settings
+# ----------------------------------------
+APP_NAME=somba-api
+APP_ENV=test
+APP_PORT=8081
+APP_SECRET_KEY=SuperSecretKeyChangeMeTest
+
+# ----------------------------------------
+# PostgreSQL Database (Test/CI) Config
+# ----------------------------------------
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=somba_ci_user
+DB_PASSWORD=StrongSombaCiPostgresPass123!
+DB_NAME=somba_ci_db
+
+# ----------------------------------------
+# MongoDB (Test/CI) Config
+# ----------------------------------------
+MONGO_HOST=mongodb
+MONGO_PORT=27017
+MONGO_INITDB_ROOT_USERNAME=somba_ci_mongo_user
+MONGO_INITDB_ROOT_PASSWORD=StrongSombaCiMongoPass123!
+MONGO_DB=somba_ci_catalog
+
+# ----------------------------------------
+# Elasticsearch (Test/CI) Config
+# ----------------------------------------
+ELASTICSEARCH_PORT=9200
+ELASTICSEARCH_PORT_ALT=9300
+ELASTICSEARCH_JAVA_OPTS=-Xms256m -Xmx256m
+
+# ----------------------------------------
+# Kibana (Test/CI) Config
+# ----------------------------------------
+KIBANA_PORT=5601
+
+# ----------------------------------------
+# API Versioning
+# ----------------------------------------
+API_VERSION=v1
+
+# ----------------------------------------
+# Server Config (Optional - CI)
+# ----------------------------------------
+SERVER_HOST=localhost
+SERVER_PORT=8081
+SERVER_ENABLE_SSL=false
+SERVER_CORS_ORIGIN=*

--- a/app/api/docker-compose.ci.yml
+++ b/app/api/docker-compose.ci.yml
@@ -1,0 +1,71 @@
+version: "3.8"
+
+services:
+  # PostgreSQL Database
+  postgres:
+    image: postgres:16.1-alpine
+    container_name: somba_postgres
+    restart: always
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    ports:
+      - "${DB_PORT}:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # MongoDB NoSQL Database
+  mongodb:
+    image: mongo:6.0
+    container_name: somba_mongodb
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
+      MONGO_INITDB_DATABASE: ${MONGO_DB}
+    ports:
+      - "${MONGO_PORT}:27017"
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD-SHELL", "echo 'db.runCommand(\"ping\").ok' | mongosh localhost:27017/test --quiet"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    container_name: somba_elasticsearch
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=${ELASTICSEARCH_JAVA_OPTS}
+      - xpack.security.enabled=false
+      - xpack.monitoring.collection.enabled=true
+    ports:
+      - "${ELASTICSEARCH_PORT}:9200"
+      - "${ELASTICSEARCH_PORT_ALT}:9300"
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
+    restart: unless-stopped
+
+volumes:
+  db-data:
+  mongo-data:
+  es-data:

--- a/app/api/pom.xml
+++ b/app/api/pom.xml
@@ -94,33 +94,6 @@
             <scope>test</scope>
         </dependency>
 
-
-        <!-- Testcontainers for Integration Testing -->
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>mongodb</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
-        </dependency>
-
         <!-- DevTools -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/app/api/src/main/java/com/somba/api/adapter/mappers/ProductMapper.java
+++ b/app/api/src/main/java/com/somba/api/adapter/mappers/ProductMapper.java
@@ -82,13 +82,13 @@ public class ProductMapper {
         .setCategory(product.category().name());
   }
 
-  public ProductSearchView toProductSearchView(Product product, double score) {
+  public ProductSearchView toProductSearchView(Product product, double rating) {
     return new ProductSearchView(
         product.id().toString(),
         product.name(),
         product.brand(),
         product.price(),
-        score,
+        rating,
         product.countReviews());
   }
 }

--- a/app/api/src/test/java/com/somba/api/e2e/BaseE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/BaseE2ETest.java
@@ -2,55 +2,19 @@ package com.somba.api.e2e;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.somba.api.core.ports.ProductRepository;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"spring.profiles.active=test"}
 )
-@Testcontainers
 public abstract class BaseE2ETest {
 
-    // Define Docker images as constants
-    private static final String POSTGRES_IMAGE = "postgres:latest";
-    private static final String MONGO_IMAGE = "mongo:latest";
-    private static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.17.0";
-
-    // Initialize PostgreSQL Container
-    @Container
-    protected static final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>(POSTGRES_IMAGE);
-
-    // Initialize MongoDB Container
-    @Container
-    protected static final MongoDBContainer mongoDBContainer = new MongoDBContainer(MONGO_IMAGE);
-
-    @Container
-    public static ElasticsearchContainer elasticsearchContainer = new ElasticsearchContainer(
-            DockerImageName.parse(ELASTICSEARCH_IMAGE))
-            .withEnv("discovery.type", "single-node")
-                .withEnv("xpack.security.enabled", "false"); // Disable security
-
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-        registry.add("spring.elasticsearch.uris", elasticsearchContainer::getHttpHostAddress);
-    }
-
-    // Injected beans
     @LocalServerPort
     protected int port;
 
@@ -72,6 +36,4 @@ public abstract class BaseE2ETest {
         // Clear existing data before each test
         productRepository.deleteAll();
     }
-
-    // Common helper methods can be added here
 }

--- a/app/api/src/test/java/com/somba/api/e2e/CreateReviewE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/CreateReviewE2ETest.java
@@ -15,7 +15,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.somba.api.core.entities.Product;
 import com.somba.api.core.enums.Category;
@@ -25,7 +24,6 @@ import com.somba.api.adapter.presenters.ErrorDetails;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
     "spring.profiles.active=test" })
-@Testcontainers
 class CreateReviewE2ETest extends BaseE2ETest {
 
   private static final MediaType CONTENT_TYPE_JSON = MediaType.APPLICATION_JSON;

--- a/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsByCategoryE2ETest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.somba.api.adapter.presenters.ErrorDetails;
 import com.somba.api.adapter.presenters.ProductView;
@@ -23,7 +22,6 @@ import com.somba.api.core.enums.Category;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
     "spring.profiles.active=test" })
-@Testcontainers
 class PaginatedProductsByCategoryE2ETest extends BaseE2ETest {
 
   @BeforeEach

--- a/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/PaginatedProductsE2ETest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.*;
 
-import org.testcontainers.junit.jupiter.Testcontainers;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -22,7 +20,6 @@ import org.junit.jupiter.api.Assertions;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"spring.profiles.active=test"}
 )
-@Testcontainers
 class PaginatedProductsE2ETest extends BaseE2ETest {
 
     @BeforeEach

--- a/app/api/src/test/java/com/somba/api/e2e/SearchProductsE2ETest.java
+++ b/app/api/src/test/java/com/somba/api/e2e/SearchProductsE2ETest.java
@@ -3,7 +3,6 @@ package com.somba.api.e2e;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import org.checkerframework.checker.units.qual.s;
 import org.junit.jupiter.api.Assertions;
 
 
@@ -18,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.somba.api.adapter.presenters.ProductSearchView;
 import com.somba.api.adapter.presenters.Response;
@@ -28,7 +26,6 @@ import com.somba.api.infrastructure.search.ProductDocument;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
         "spring.profiles.active=test" })
-@Testcontainers
 class SearchProductsE2ETest extends BaseE2ETest {
 
     @Autowired

--- a/app/api/src/test/java/com/somba/api/infrastructure/persistence/AverageReviewsTest.java
+++ b/app/api/src/test/java/com/somba/api/infrastructure/persistence/AverageReviewsTest.java
@@ -7,27 +7,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-
 import com.somba.api.infrastructure.persistence.entities.ReviewEntity;
 
 @DataMongoTest
-@Testcontainers
 class AverageReviewsTest {
-    @Container
-  static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");
 
   @Autowired
   private MdbReviewRepository mdbReviewRepository;
-
-  @DynamicPropertySource
-  static void mongoProperties(DynamicPropertyRegistry registry) {
-    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-  }
 
   @BeforeEach
   void setUp() {

--- a/app/api/src/test/java/com/somba/api/infrastructure/persistence/MongoProductRepositoryPaginatedProductsTest.java
+++ b/app/api/src/test/java/com/somba/api/infrastructure/persistence/MongoProductRepositoryPaginatedProductsTest.java
@@ -3,12 +3,6 @@ package com.somba.api.infrastructure.persistence;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.somba.api.infrastructure.persistence.entities.ProductEntity;
@@ -20,19 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DataMongoTest
-@Testcontainers
 class MongoProductRepositoryPaginatedProductsTest {
-
-  @Container
-  static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");
 
   @Autowired
   private MdbProductRepository mdbProductRepository;
-
-  @DynamicPropertySource
-  static void mongoProperties(DynamicPropertyRegistry registry) {
-    registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-  }
 
   @BeforeEach
   void setUp() {

--- a/app/api/src/test/java/com/somba/api/infrastructure/persistence/MongoProductRepositorySearchByCategoryTest.java
+++ b/app/api/src/test/java/com/somba/api/infrastructure/persistence/MongoProductRepositorySearchByCategoryTest.java
@@ -15,32 +15,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.somba.api.infrastructure.persistence.entities.ProductEntity;
 
 @DataMongoTest
-@Testcontainers
 class MongoProductRepositorySearchByCategoryTest {
 
     private static final String CATEGORY_ONE = "category-one";
     private static final String CATEGORY_TWO = "category-two";
     private static final String CATEGORY_SPORTS = "sports";
 
-    @Container
-    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");
-
     @Autowired
     private MdbProductRepository mdbProductRepository;
-
-    @DynamicPropertySource
-    static void mongoProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
-    }
 
     @BeforeEach
     void setUp() {

--- a/app/api/src/test/java/com/somba/api/infrastructure/search/ProductSearchRepositoryTest.java
+++ b/app/api/src/test/java/com/somba/api/infrastructure/search/ProductSearchRepositoryTest.java
@@ -8,18 +8,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.elasticsearch.DataElasticsearchTest;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers
 @DataElasticsearchTest
 class ProductSearchRepositoryTest {
 
@@ -28,20 +20,6 @@ class ProductSearchRepositoryTest {
 
     @Autowired
     private ElasticsearchOperations elasticsearchOperations;
-
-    private static final String ELASTICSEARCH_DOCKER_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.17.0";
-
-    @Container
-    public static ElasticsearchContainer elasticsearchContainer = new ElasticsearchContainer(DockerImageName.parse(ELASTICSEARCH_DOCKER_IMAGE))
-                .withEnv("discovery.type", "single-node")
-                .withEnv("xpack.security.enabled", "false") // Disable security
-                .withExposedPorts(9200, 9300) // Ensure ports are exposed
-                .waitingFor(org.testcontainers.containers.wait.strategy.Wait.forHttp("/").forStatusCode(200)); // Wait until Elasticsearch is up
-
-    @DynamicPropertySource
-    static void setElasticsearchProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.elasticsearch.uris", elasticsearchContainer::getHttpHostAddress);
-    }
 
     @BeforeEach
     void setUp() {

--- a/app/api/src/test/resources/application.yml
+++ b/app/api/src/test/resources/application.yml
@@ -8,20 +8,55 @@ spring:
   profiles:
     active: test
 
+  # ----------------------------------------
+  # Override the PostgreSQL DB for Tests
+  # ----------------------------------------
+  datasource:
+    url: jdbc:postgresql://localhost:${DB_PORT:5432}/${DB_NAME:somba_test_db}
+    username: ${DB_USER:postgres}
+    password: ${DB_PASSWORD:securepassword}
+    driver-class-name: org.postgresql.Driver
+
+  # ----------------------------------------
+  # Override JPA Behavior for Tests
+  # ----------------------------------------
   jpa:
     hibernate:
-      ddl-auto: update  # Consider using 'create-drop' for isolated tests
-    show-sql: true      # Enable SQL logging for debugging
+      ddl-auto: create-drop  # 'create-drop' or 'update' (create-drop is safer for true isolation)
+    show-sql: true           # Enable SQL logging for debugging tests
     open-in-view: false
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+  # ----------------------------------------
+  # MongoDB for Tests
+  # ----------------------------------------
+  data:
+    mongodb:
+      host: localhost
+      port: ${MONGO_PORT:27017}
+      database: ${MONGO_DB:somba_test_catalog}
+      username: ${MONGO_INITDB_ROOT_USERNAME:root}
+      password: ${MONGO_INITDB_ROOT_PASSWORD:securepassword}
+      authentication-database: admin
+
+  # ----------------------------------------
+  # Elasticsearch for Tests
+  # ----------------------------------------
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URL:http://localhost:9200}
+    connection-timeout: 1s
+
+# ----------------------------------------
+# Override Server Port to Avoid Conflicts
+# ----------------------------------------
 server:
-  port: ${APP_PORT:8082}  # Use a different port to avoid conflicts
+  port: ${APP_PORT:8082}
   servlet:
     context-path: /api/${API_VERSION:v1}
+
 # ----------------------------------------
 # Logging Configuration for Testing
 # ----------------------------------------
@@ -37,7 +72,7 @@ logging:
 # CORS Configuration for Testing
 # ----------------------------------------
 cors:
-  allowed-origins: "*"  # Adjust as necessary
+  allowed-origins: "*"
   allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
   allowed-headers: "*"
   exposed-headers: "Authorization"

--- a/app/api/src/test/resources/application.yml
+++ b/app/api/src/test/resources/application.yml
@@ -12,7 +12,7 @@ spring:
   # PostgreSQL Database (Test)
   # ----------------------------------------
   datasource:
-    url: jdbc:postgresql://postgres:5432/somba_ci_db
+    url: jdbc:postgresql://localhost:5432/somba_ci_catalog
     username: somba_ci_user
     password: StrongSombaCiPostgresPass123!
     driver-class-name: org.postgresql.Driver
@@ -36,7 +36,7 @@ spring:
   # ----------------------------------------
   data:
     mongodb:
-      host: mongodb
+      host: localhost
       port: 27017
       database: somba_ci_catalog
       username: somba_ci_mongo_user
@@ -47,7 +47,7 @@ spring:
   # Elasticsearch (Test)
   # ----------------------------------------
   elasticsearch:
-    uris: http://elasticsearch:9200
+    uris: http://localhost:9200
     connection-timeout: 1s
 
 # ----------------------------------------

--- a/app/api/src/test/resources/application.yml
+++ b/app/api/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 # ----------------------------------------
-# Spring Boot Core Settings for Testing
+# Spring Boot Core (Test Profile)
 # ----------------------------------------
 spring:
   application:
@@ -9,21 +9,22 @@ spring:
     active: test
 
   # ----------------------------------------
-  # Override the PostgreSQL DB for Tests
+  # PostgreSQL Database (Test)
   # ----------------------------------------
   datasource:
-    url: jdbc:postgresql://localhost:${DB_PORT:5432}/${DB_NAME:somba_test_db}
-    username: ${DB_USER:postgres}
-    password: ${DB_PASSWORD:securepassword}
+    url: jdbc:postgresql://postgres:5432/somba_ci_db
+    username: somba_ci_user
+    password: StrongSombaCiPostgresPass123!
     driver-class-name: org.postgresql.Driver
 
   # ----------------------------------------
-  # Override JPA Behavior for Tests
+  # JPA/Hibernate Settings
   # ----------------------------------------
   jpa:
     hibernate:
-      ddl-auto: create-drop  # 'create-drop' or 'update' (create-drop is safer for true isolation)
-    show-sql: true           # Enable SQL logging for debugging tests
+      # 'create-drop' ensures a fresh schema each test run
+      ddl-auto: create-drop
+    show-sql: true
     open-in-view: false
     properties:
       hibernate:
@@ -31,45 +32,45 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
   # ----------------------------------------
-  # MongoDB for Tests
+  # MongoDB (Test)
   # ----------------------------------------
   data:
     mongodb:
-      host: localhost
-      port: ${MONGO_PORT:27017}
-      database: ${MONGO_DB:somba_test_catalog}
-      username: ${MONGO_INITDB_ROOT_USERNAME:root}
-      password: ${MONGO_INITDB_ROOT_PASSWORD:securepassword}
+      host: mongodb
+      port: 27017
+      database: somba_ci_catalog
+      username: somba_ci_mongo_user
+      password: StrongSombaCiMongoPass123!
       authentication-database: admin
 
   # ----------------------------------------
-  # Elasticsearch for Tests
+  # Elasticsearch (Test)
   # ----------------------------------------
   elasticsearch:
-    uris: ${ELASTICSEARCH_URL:http://localhost:9200}
+    uris: http://elasticsearch:9200
     connection-timeout: 1s
 
 # ----------------------------------------
-# Override Server Port to Avoid Conflicts
+# Server Settings (Test)
 # ----------------------------------------
 server:
-  port: ${APP_PORT:8082}
+  port: 8081
   servlet:
-    context-path: /api/${API_VERSION:v1}
+    context-path: /api/v1
 
 # ----------------------------------------
-# Logging Configuration for Testing
+# Logging Configuration
 # ----------------------------------------
 logging:
   level:
     root: INFO
-    org.springframework: DEBUG  # Increase verbosity for debugging
+    org.springframework: DEBUG
     com.somba: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - [%thread] %-5level %logger{36} - %msg%n"
 
 # ----------------------------------------
-# CORS Configuration for Testing
+# CORS Configuration
 # ----------------------------------------
 cors:
   allowed-origins: "*"
@@ -78,7 +79,7 @@ cors:
   exposed-headers: "Authorization"
 
 # ----------------------------------------
-# API Versioning for Testing
+# API Versioning
 # ----------------------------------------
 api:
-  version: ${API_VERSION:test_v1}
+  version: v1


### PR DESCRIPTION
This pull request includes significant changes to the CI workflow, Docker configuration, and test setup. The main changes involve updating the CI workflow to include additional paths, adding environment variables for database services, and transitioning from Testcontainers to Docker Compose for service management in tests.

### CI Workflow and Environment Configuration:

* [`.github/workflows/api-ci.yml`](diffhunk://#diff-4d5b51f0d2cf831dd4f3c8083cc1eb5bc1c7e0c1a3d94311d6705579d70cef10L22-L30): Updated the paths to include workflow files and added environment variables for database services. Introduced steps to start and tear down Docker services during the CI process. [[1]](diffhunk://#diff-4d5b51f0d2cf831dd4f3c8083cc1eb5bc1c7e0c1a3d94311d6705579d70cef10L22-L30) [[2]](diffhunk://#diff-4d5b51f0d2cf831dd4f3c8083cc1eb5bc1c7e0c1a3d94311d6705579d70cef10R38-R51) [[3]](diffhunk://#diff-4d5b51f0d2cf831dd4f3c8083cc1eb5bc1c7e0c1a3d94311d6705579d70cef10R78-R87) [[4]](diffhunk://#diff-4d5b51f0d2cf831dd4f3c8083cc1eb5bc1c7e0c1a3d94311d6705579d70cef10L78) [[5]](diffhunk://#diff-4d5b51f0d2cf831dd4f3c8083cc1eb5bc1c7e0c1a3d94311d6705579d70cef10R112-R115)

### Docker Configuration:

* [`app/api/docker-compose.ci.yml`](diffhunk://#diff-6a50d9550268a3c4bcc0b93634204db93ad1453af79281fbc396883140b312c3R1-R71): Added a new Docker Compose configuration file to manage PostgreSQL, MongoDB, and Elasticsearch services for CI.

### Test Setup:

* [`app/api/src/test/java/com/somba/api/e2e/BaseE2ETest.java`](diffhunk://#diff-5939d6227294ea86aa3660c91fcd1bbd73be2af6aaa04f9efd69164f150f239cR5-L53): Removed Testcontainers setup and configuration, transitioning to using Docker Compose for managing test dependencies. [[1]](diffhunk://#diff-5939d6227294ea86aa3660c91fcd1bbd73be2af6aaa04f9efd69164f150f239cR5-L53) [[2]](diffhunk://#diff-5939d6227294ea86aa3660c91fcd1bbd73be2af6aaa04f9efd69164f150f239cL75-L76)
* [`app/api/src/test/resources/application.yml`](diffhunk://#diff-61511a51b24dc8d33cd4afdbc83bf844fa83bc8a39dc5520ac828e0f9df4894eR11-R59): Updated test configuration to use Docker Compose service URLs and credentials. [[1]](diffhunk://#diff-61511a51b24dc8d33cd4afdbc83bf844fa83bc8a39dc5520ac828e0f9df4894eR11-R59) [[2]](diffhunk://#diff-61511a51b24dc8d33cd4afdbc83bf844fa83bc8a39dc5520ac828e0f9df4894eL40-R75)

### Code Refactoring:

* [`app/api/src/main/java/com/somba/api/adapter/mappers/ProductMapper.java`](diffhunk://#diff-c9517d11d411a0d925d50d9d35c0392e167295423cafaa391be965f0437a21a4L85-R91): Renamed the `score` parameter to `rating` in the `toProductSearchView` method to improve clarity.

### Test Cleanup:

* Removed `@Testcontainers` annotations from various test classes as they are no longer needed with the new Docker Compose setup. [[1]](diffhunk://#diff-ac8817efca8ec3bbcf7f873fc1c7ea6d969229a9173c72e2eba5650b6b9b1b43L18) [[2]](diffhunk://#diff-ac8817efca8ec3bbcf7f873fc1c7ea6d969229a9173c72e2eba5650b6b9b1b43L28) [[3]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L16) [[4]](diffhunk://#diff-63c2cfa83e9508678cd7eb68a6253a63e5f77a027f9a8dc4a574fa1cab5dcd91L26) [[5]](diffhunk://#diff-19356c373103b50626ce408c957c0fd1bc82df25c626a0b96dd2bd818e5bf7b5L13-L14) [[6]](diffhunk://#diff-19356c373103b50626ce408c957c0fd1bc82df25c626a0b96dd2bd818e5bf7b5L25) [[7]](diffhunk://#diff-5a440159014e42a8056b34bbb5d941f9849b4bedd714293d995a40af14f757f2L6) [[8]](diffhunk://#diff-5a440159014e42a8056b34bbb5d941f9849b4bedd714293d995a40af14f757f2L21) [[9]](diffhunk://#diff-5a440159014e42a8056b34bbb5d941f9849b4bedd714293d995a40af14f757f2L31)